### PR TITLE
Added GitHub  URL into the description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Version: 3.5.0.2
 Date: 2022-05-09
 Title: Epidemiological Data Display Package
 Author: Virasakdi Chongsuvivatwong <cvirasak@medicine.psu.ac.th>
+URL: https://github.com/cran/epiDisplay
 Maintainer: Virasakdi Chongsuvivatwong <cvirasak@medicine.psu.ac.th>
 Depends: R (>= 2.6.2), foreign, survival, MASS, nnet
 Suggests:


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION